### PR TITLE
Fix parallel build

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -27,7 +27,8 @@ include $(top_srcdir)/lib/Headers.mk
 headers += $(libfribidi_la_headers)
 includepath += -I$(top_builddir)/lib -I$(top_srcdir)/lib
 includevpath += :$(top_builddir)/lib:$(top_srcdir)/lib
-inst_symbols += $(libfribidi_la_symbols)
+# The las two lines are not functions, we don't want them here.
+inst_symbols += $(shell head -n -2 $(top_srcdir)/lib/fribidi.def)
 
 dist_man_MANS += $(inst_symbols:=.3)
 dist_noinst_MANS += $(noinst_symbols:=.3)

--- a/lib/fribidi-common.h
+++ b/lib/fribidi-common.h
@@ -110,10 +110,17 @@
 
 
 #define fribidi_debug_status FRIBIDI_NAMESPACE(debug_status)
+/* fribidi_debug_status - get current debug state
+ *
+ */
 FRIBIDI_ENTRY int fribidi_debug_status (
   void
 );
+
 #define fribidi_set_debug FRIBIDI_NAMESPACE(set_debug)
+/* fribidi_set_debug - set debug state
+ *
+ */
 FRIBIDI_ENTRY int
 fribidi_set_debug (
   int state		/* new state to set */

--- a/lib/fribidi.def
+++ b/lib/fribidi.def
@@ -16,7 +16,6 @@ fribidi_get_type_internal
 fribidi_join_arabic
 fribidi_log2vis
 fribidi_log2vis_get_embedding_levels
-fribidi_log2vis_get_embedding_levels_ex
 fribidi_mirroring_status
 fribidi_remove_bidi_marks
 fribidi_reorder_line


### PR DESCRIPTION
Parallel build was failing while building the man pages. `doc/Makefile.am` tries cleverly to handle the fact that c2man produces all the man pages at once, following the approach described in:
https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html

However this is failing because c2man is not generating all the requested man pages, so the rule ends being run multiple times instead of once and parallel builds are broken. One of the requested pages is
for a function that doesn’t exist, `fribidi_log2vis_get_embedding_levels_ex`, so I removed it from `fribidi.def`.

Two functions were not documented, so I added minimal documentation for them.

But the last two are for variables not functions and c2man does not like that it seems so I added a hack to drop these two as well without modifying `fribidi.def`.

Fixes https://github.com/fribidi/fribidi/issues/45