### PR TITLE
Fix documentation installation on FreeBSD

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -29,7 +29,7 @@ headers += $(libfribidi_la_headers)
 includepath += -I$(top_builddir)/lib -I$(top_srcdir)/lib
 includevpath += :$(top_builddir)/lib:$(top_srcdir)/lib
 # The las two lines are not functions, we don't want them here.
-inst_symbols += $(shell head -n -2 $(top_srcdir)/lib/fribidi.def)
+inst_symbols += $(shell sed '$$d' $(top_srcdir)/lib/fribidi.def | sed '$$d')
 
 dist_man_MANS += $(inst_symbols:=.3)
 dist_noinst_MANS += $(noinst_symbols:=.3)


### PR DESCRIPTION
POSIX says the number after `head -n` should be a positive interger.

```
head: illegal line count -- -2
head: illegal line count -- -2
head: illegal line count -- -2
head: illegal line count -- -2
```