### PR TITLE
meson: fix docs install

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -19,7 +19,10 @@ gen_man_pages = []
 
 syms = result.stdout().strip().split('\n')
 foreach sym : syms
-  gen_man_pages += ['@0@.3'.format(sym)]
+  # for consistency with autotools build and because we don't pass -v to c2man
+  if sym != 'fribidi_unicode_version' and sym != 'fribidi_version_info'
+    gen_man_pages += ['@0@.3'.format(sym)]
+  endif
 endforeach
 
 c2man_incs = []


### PR DESCRIPTION
Follow-up fix to commit c8ad556. The .def file contains all
exported symbols including exported variables. The autotools
docs build only installs man pages for the functions however,
so we need to special-case the two variable names if we don't
want to pass '-v' to c2man to create man pages for the exported
symbols as well.