### PR TITLE
meson: don't require c2man for tarball with pre-generated man pages

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,9 +1,3 @@
-c2man = find_program('c2man', required: false)
-
-if not c2man.found()
-  error('c2man is required to build documentation. Or disable with -Ddocs=false')
-endif
-
 # Extract list of man pages (one man page per symbol) from lib/libfribidi.def
 python3 = import('python3').find_python()
 
@@ -25,18 +19,33 @@ foreach sym : syms
   endif
 endforeach
 
-c2man_incs = []
-c2man_incs += ['-I' + join_paths(meson.source_root(), 'lib')]
-c2man_incs += ['-I' + join_paths(meson.build_root(), 'lib')]
-c2man_incs += ['-I' + join_paths(meson.source_root(), 'gen.tab')]
-c2man_incs += ['-I' + join_paths(meson.build_root(), 'gen.tab')]
+# check if we have a tarball which contains the generated files
+result = run_command(python3, '-c', '''import os.path; import sys
+sys.exit(0 if os.path.isfile('@0@') else 1)'''.format(join_paths(meson.current_source_dir(), gen_man_pages[0])))
+have_man_pages = result.returncode() == 0
+message('Have pre-generated man pages: @0@'.format(have_man_pages))
 
-custom_target('man pages',
-  command: [c2man, '-T', 'n', '-M', 'Programmer\'s Manual', c2man_incs,
-            '-D__FRIBIDI_DOC', '-DDONT_HAVE_FRIBIDI_CONFIG_H',
-            '-o@0@'.format(meson.current_build_dir()),
-           fribidi_headers],
-  depends: [fribidi_unicode_version_h],
-  output: gen_man_pages,
-  install_dir: join_paths(get_option('prefix'), get_option('mandir'), 'man3'),
-  install: true)
+if have_man_pages
+  install_man(gen_man_pages)
+else
+  c2man = find_program('c2man', required: false)
+  if not c2man.found()
+    error('c2man is required to build documentation from git. Or disable with -Ddocs=false')
+  endif
+
+  c2man_incs = []
+  c2man_incs += ['-I' + join_paths(meson.source_root(), 'lib')]
+  c2man_incs += ['-I' + join_paths(meson.build_root(), 'lib')]
+  c2man_incs += ['-I' + join_paths(meson.source_root(), 'gen.tab')]
+  c2man_incs += ['-I' + join_paths(meson.build_root(), 'gen.tab')]
+
+  custom_target('man pages',
+    command: [c2man, '-T', 'n', '-M', 'Programmer\'s Manual', c2man_incs,
+              '-D__FRIBIDI_DOC', '-DDONT_HAVE_FRIBIDI_CONFIG_H',
+              '-o@0@'.format(meson.current_build_dir()),
+             fribidi_headers],
+    depends: [fribidi_unicode_version_h],
+    output: gen_man_pages,
+    install_dir: join_paths(get_option('prefix'), get_option('mandir'), 'man3'),
+    install: true)
+endif


### PR DESCRIPTION
Fixes #79

Only very lightly tested.