### PR TITLE
WIP: Add fribidi_reorder_runs()

### DIFF
--- a/lib/fribidi-bidi.c
+++ b/lib/fribidi-bidi.c
@@ -1666,6 +1666,8 @@ fribidi_reorder_runs (
   const FriBidiParType base_dir,
   /* input and output */
   FriBidiLevel *embedding_levels,
+  /* input */
+  FriBidiStrIndex out_len,
   /* output */
   FriBidiStrIndex *run_positions,
   FriBidiStrIndex *run_lengths,
@@ -1722,18 +1724,20 @@ fribidi_reorder_runs (
       run = run->next;
     }
 
-  if (run_positions == NULL || run_lengths == NULL || run_levels == NULL)
+  if (out_len <= 0 || !run_positions || !run_lengths || !run_levels)
     goto out;
 
   runs = linear_reorder (runs);
 
+  i = 0;
   run = runs;
-  while (run)
+  while (run && i < out_len)
     {
-      *(run_positions++) = run->pos;
-      *(run_lengths++) = run->len;
-      *(run_levels++) = run->level;
+      run_positions[i] = run->pos;
+      run_lengths[i] = run->len;
+      run_levels[i] = run->level;
       run = run->next;
+      i++;
     }
 
 out:

--- a/lib/fribidi-bidi.c
+++ b/lib/fribidi-bidi.c
@@ -1544,6 +1544,212 @@ out:
   return status ? max_level + 1 : 0;
 }
 
+struct range_t
+{
+  FriBidiLevel level;
+  /* Left-most and right-most runs in the range, in visual order.
+   * Following left's next member eventually gets us to right.
+   * The right run's next member is undefined. */
+  FriBidiRun *left;
+  FriBidiRun *right;
+  struct range_t *previous;
+};
+
+static struct range_t *
+merge_range_with_previous (
+  struct range_t *range
+)
+{
+  struct range_t *previous = range->previous;
+  struct range_t *left, *right;
+
+  fribidi_assert (range->previous);
+  fribidi_assert (previous->level < range->level);
+
+  if (FRIBIDI_LEVEL_IS_RTL (previous->level))
+  {
+    /* Odd, previous goes to the right of range. */
+    left = range;
+    right = previous;
+  }
+  else
+  {
+    /* Even, previous goes to the left of range. */
+    left = previous;
+    right = range;
+  }
+  /* Stich them. */
+  left->right->next = right->left;
+
+  previous->left = left->left;
+  previous->right = right->right;
+
+  fribidi_free (range);
+  return previous;
+}
+
+static FriBidiRun *
+linear_reorder (
+  FriBidiRun *runs
+)
+{
+  /* The algorithm here is something like this: sweep runs in the
+   * logical order, keeping a stack of ranges.  Upon seeing a run,
+   * we flatten all ranges before it that have a level higher than
+   * the run, by merging them, reordering as we go.  Then we either
+   * merge the run with the previous range, or create a new range
+   * for the run, depending on the level relationship.
+   */
+  struct range_t *range = NULL;
+  FriBidiRun *run;
+
+  if (!runs)
+    return NULL;
+
+  run = runs;
+  while (run)
+  {
+    FriBidiRun *next_run = run->next;
+
+    while (range && range->level > run->level &&
+           range->previous && range->previous->level >= run->level)
+      range = merge_range_with_previous (range);
+
+    if (range && range->level >= run->level)
+    {
+      /* Attach run to the range. */
+      if (FRIBIDI_LEVEL_IS_RTL (run->level))
+      {
+        /* Odd, range goes to the right of run. */
+        run->next = range->left;
+        range->left = run;
+      }
+      else
+      {
+        /* Even, range goes to the left of run. */
+        range->right->next = run;
+        range->right = run;
+      }
+      range->level = run->level;
+    }
+    else
+    {
+      /* Allocate new range for run and push into stack. */
+      struct range_t *r = fribidi_malloc (sizeof (struct range_t));
+      r->left = r->right = run;
+      r->level = run->level;
+      r->previous = range;
+      range = r;
+    }
+
+    run = next_run;
+  }
+
+  fribidi_assert (range);
+  while (range->previous)
+    range = merge_range_with_previous (range);
+
+  /* Terminate. */
+  range->right->next = NULL;
+
+  run = range->left;
+  fribidi_free (range);
+
+  return run;
+}
+
+FRIBIDI_ENTRY FriBidiStrIndex
+fribidi_reorder_runs (
+  /* input */
+  const FriBidiCharType *bidi_types,
+  const FriBidiStrIndex len,
+  const FriBidiParType base_dir,
+  /* input and output */
+  FriBidiLevel *embedding_levels,
+  /* output */
+  FriBidiStrIndex *run_positions,
+  FriBidiStrIndex *run_lengths,
+  FriBidiLevel *run_levels
+)
+{
+  FriBidiStrIndex i;
+  FriBidiStrIndex run_count = 0;
+  FriBidiStrIndex run_pos = 0;
+  FriBidiRun *run;
+  FriBidiRun *runs = NULL;
+
+  if UNLIKELY
+    (!len)
+    {
+      goto out;
+    }
+
+  DBG ("in fribidi_reorder_runs");
+
+  fribidi_assert (bidi_types);
+  fribidi_assert (embedding_levels);
+
+  DBG ("reset the embedding levels, 4. whitespace at the end of line");
+  {
+    /* L1. Reset the embedding levels of some chars:
+       4. any sequence of white space characters at the end of the line. */
+    for (i = len - 1; i >= 0 &&
+         FRIBIDI_IS_EXPLICIT_OR_BN_OR_WS (bidi_types[i]); i--)
+      embedding_levels[i] = FRIBIDI_DIR_TO_LEVEL (base_dir);
+  }
+
+  while (run_pos < len)
+    {
+      FriBidiStrIndex run_len = 0;
+      while ((run_pos + run_len) < len &&
+             embedding_levels[run_pos] == embedding_levels[run_pos + run_len])
+        run_len++;
+
+      run = new_run ();
+      run->pos = run_pos;
+      run->level = embedding_levels[run_pos];
+      run->len = run_len;
+      run->next = runs;
+      runs = run;
+
+      run_pos += run_len;
+    }
+
+  run = runs;
+  while (run)
+    {
+      run_count++;
+      run = run->next;
+    }
+
+  if (run_positions == NULL || run_lengths == NULL || run_levels == NULL)
+    goto out;
+
+  runs = linear_reorder (runs);
+
+  run = runs;
+  while (run)
+    {
+      *(run_positions++) = run->pos;
+      *(run_lengths++) = run->len;
+      *(run_levels++) = run->level;
+      run = run->next;
+    }
+
+out:
+
+  run = runs;
+  while (run)
+    {
+      FriBidiRun *p = run;
+      run = run->next;
+      fribidi_free (p);
+    }
+
+  return run_count;
+}
+
+
 /* Editor directions:
  * vim:textwidth=78:tabstop=8:shiftwidth=2:autoindent:cindent
  */

--- a/lib/fribidi-bidi.h
+++ b/lib/fribidi-bidi.h
@@ -148,20 +148,21 @@ fribidi_get_par_embedding_levels_ex (
  * space at the end of line is reset to the paragraph embedding level (That is
  * part 4 of rule L1).
  *
- * The runs array can be NULL and in this case no reordring will happen, only
- * the count of the runs will be returned.
+ * The if out_len is <= zero or any of the output arrays is NULL, no reordring
+ * will happen, and the number of the runs will be returned.
  *
  * Returns: number of the runs.
  */
 FRIBIDI_ENTRY FriBidiStrIndex
 fribidi_reorder_runs (
-  const FriBidiCharType *bidi_types,	/* input list of bidi types as returned by fribidi_get_bidi_types() */
-  const FriBidiStrIndex len,	/* input length of the line */
+  const FriBidiCharType *bidi_types,	/* list of bidi types as returned by fribidi_get_bidi_types() */
+  const FriBidiStrIndex len,		/* length of input arrays */
   const FriBidiParType base_dir,	/* resolved paragraph base direction */
-  FriBidiLevel *embedding_levels,	/* input list of embedding levels, as returned by fribidi_get_par_embedding_levels */
+  FriBidiLevel *embedding_levels,	/* list of embedding levels, as returned by fribidi_get_par_embedding_levels() */
+  FriBidiStrIndex out_len,		/* length of the output arrays */
   FriBidiStrIndex *run_positions,	/* output list of run positions */
-  FriBidiStrIndex *run_lengths,	/* output list of run lengths */
-  FriBidiLevel *run_levels	/* output list of run embedding levels */
+  FriBidiStrIndex *run_lengths,		/* output list of run lengths */
+  FriBidiLevel *run_levels		/* output list of run embedding levels */
 ) FRIBIDI_GNUC_WARN_UNUSED;
 
 #include "fribidi-enddecls.h"

--- a/lib/fribidi-bidi.h
+++ b/lib/fribidi-bidi.h
@@ -134,6 +134,36 @@ fribidi_get_par_embedding_levels_ex (
 				 * to reflect where each glyph ends up. */
 ) FRIBIDI_GNUC_WARN_UNUSED;
 
+/* fribidi_reorder_runs - reorder runs of logical string to visual
+ *
+ * This function reorders all runs from logical to final visual order.  This
+ * function implements part 4 of rule L1 and rule L2 of the Unicode
+ * Bidirectional Algorithm available at
+ * http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels.
+ *
+ * You should provide the bidi types as returned by fribidi_get_bidi_types()
+ * and the resolved embedding levels as set by
+ * fribidi_get_par_embedding_levels().  Also note that the embedding levels may
+ * change a bit.  To be exact, the embedding level of any sequence of white
+ * space at the end of line is reset to the paragraph embedding level (That is
+ * part 4 of rule L1).
+ *
+ * The runs array can be NULL and in this case no reordring will happen, only
+ * the count of the runs will be returned.
+ *
+ * Returns: number of the runs.
+ */
+FRIBIDI_ENTRY FriBidiStrIndex
+fribidi_reorder_runs (
+  const FriBidiCharType *bidi_types,	/* input list of bidi types as returned by fribidi_get_bidi_types() */
+  const FriBidiStrIndex len,	/* input length of the line */
+  const FriBidiParType base_dir,	/* resolved paragraph base direction */
+  FriBidiLevel *embedding_levels,	/* input list of embedding levels, as returned by fribidi_get_par_embedding_levels */
+  FriBidiStrIndex *run_positions,	/* output list of run positions */
+  FriBidiStrIndex *run_lengths,	/* output list of run lengths */
+  FriBidiLevel *run_levels	/* output list of run embedding levels */
+) FRIBIDI_GNUC_WARN_UNUSED;
+
 #include "fribidi-enddecls.h"
 
 #endif /* !_FRIBIDI_BIDI_H */

--- a/lib/fribidi.def
+++ b/lib/fribidi.def
@@ -22,6 +22,7 @@ fribidi_parse_charset
 fribidi_remove_bidi_marks
 fribidi_reorder_line
 fribidi_reorder_nsm_status
+fribidi_reorder_runs
 fribidi_set_debug
 fribidi_set_mirroring
 fribidi_set_reorder_nsm


### PR DESCRIPTION
Uses Behdad’s linear reorder from:
https://github.com/behdad/linear-reorder/

Rebased on master, and partially reverts d36fab04a6332952556bbf1023c6ba54015ec4c4, but I didn’t actually test it, just to see if this is the kind of API we want. Supersedes #11, and should fix #30.