### PR TITLE
tests: Fix build on pre-C99 compilers

### DIFF
--- a/test/unicode-conformance/BidiCharacterTest.c
+++ b/test/unicode-conformance/BidiCharacterTest.c
@@ -289,8 +289,9 @@ main (int argc, char **argv)
 	die ("Failed opening %s\n", filename);
 
     while (!feof(channel)) {
+      int len;
       fgets(line, LINE_SIZE, channel);
-      int len = strlen(line);
+      len = strlen(line);
       if (len == LINE_SIZE-1)
         die("LINE_SIZE=%d too small at line %d!\n", LINE_SIZE, line_no);
 

--- a/test/unicode-conformance/BidiTest.c
+++ b/test/unicode-conformance/BidiTest.c
@@ -288,8 +288,9 @@ main (int argc, char **argv)
 	die ("Failed opening %s\n", filename);
 
     while (!feof(channel)) {
+        int len;
         fgets(line, LINE_SIZE, channel);
-        int len = strlen(line);
+        len = strlen(line);
         if (len == LINE_SIZE-1)
           die("LINE_SIZE too small at line %d!\n", line_no);
 


### PR DESCRIPTION
Hi,

This MR updates the test programs so that they build on pre-C99 compilers as well, since the fribidi library itself builds on such compilers already.

With blessings, thank you!