### PR TITLE
meson: Pass visibility args to test executable

### DIFF
--- a/test/unicode-conformance/meson.build
+++ b/test/unicode-conformance/meson.build
@@ -5,7 +5,7 @@ tests = [
 foreach t : tests
   exe = executable(t[0],
     t[1], fribidi_unicode_version_h,
-    c_args: ['-DHAVE_CONFIG_H'],
+    c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
     include_directories: incs,
     link_with: libfribidi)
   test(t[0], exe, args: files('@0@.txt'.format(t[0])))


### PR DESCRIPTION
It appears I missed an executable in my previous commit since it wasn't getting run by default on the VS backend, apologies. This should be everything, since the executables in gen.tab don't appear to link libfribidi. The ninja backend with msvc runs successfully with this commit.