### PR TITLE
Misc. source comment and documentation typo fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,7 +39,7 @@ Overview of changes between 0.19.7 and 1.0
   `fribidi_get_par_embedding_levels()` must be replaced with calls to
   `fribidi_get_par_embedding_levels_ex()`. These function are not API
   compatible. Calling the older function will use default values for
-  the new bracket properties and will sometimes yield non-complient
+  the new bracket properties and will sometimes yield non-compliant
   results.
 
 Overview of changes between 0.19.6 and 0.19.7

--- a/lib/fribidi-bidi.c
+++ b/lib/fribidi-bidi.c
@@ -289,7 +289,7 @@ static void print_pairing_nodes(FriBidiPairingNode *nodes)
  * define macros for push and pop the status in to / out of the stack
  *-------------------------------------------------------------------------*/
 
-/* There are a few little points in pushing into and poping from the status
+/* There are a few little points in pushing into and popping from the status
    stack:
    1. when the embedding level is not valid (more than
    FRIBIDI_BIDI_MAX_EXPLICIT_LEVEL=125), you must reject it, and not to push

--- a/lib/fribidi-char-sets.h
+++ b/lib/fribidi-char-sets.h
@@ -70,7 +70,7 @@ FRIBIDI_ENTRY FriBidiStrIndex fribidi_charset_to_unicode (
  * Returns: The length of the new string.
  */
 FRIBIDI_ENTRY FriBidiStrIndex fribidi_unicode_to_charset (
-  FriBidiCharSet char_set,	/* character set to conver to */
+  FriBidiCharSet char_set,	/* character set to convert to */
   const FriBidiChar *us,	/* input Unicode string */
   FriBidiStrIndex len,		/* input string length */
   char *s			/* output string encoded in char_set */

--- a/lib/fribidi-common.h
+++ b/lib/fribidi-common.h
@@ -49,7 +49,7 @@
  * The dllimport is needed here mostly for the fribidi_version_info variable,
  * for functions it's not required. Probably needs more fine-tuning if
  * someone starts building fribidi as static library with MSVC. We'll cross
- * that brige when we get there. */
+ * that bridge when we get there. */
 #  define FRIBIDI_ENTRY __declspec(dllimport) extern
 # else
 #  define FRIBIDI_ENTRY extern


### PR DESCRIPTION
Found via `codespell -q 3 -S ./gen.tab`