### PR TITLE
Updated Travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
 
-sudo: false
-
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ matrix:
       python: 3.5
       env: PATH=$PATH:$TRAVIS_BUILD_DIR/c2man-install
       install:
-        - pip install ninja
-          # XXX: Move back to the latest release once 0.48.1 is out
-        - pip install git+https://github.com/mesonbuild/meson@0.48
+        - pip install meson ninja
       before_script:
         - bash .ci/build-c2man.sh
       script:


### PR DESCRIPTION
* Removed 'sudo'. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
* Reverted the static meson version, since 0.48.1 has been released.