### PR TITLE
Properly export fribidi_unicode_version

### DIFF
--- a/lib/fribidi.h
+++ b/lib/fribidi.h
@@ -52,6 +52,8 @@
 
 
 
+FRIBIDI_ENTRY const char *fribidi_unicode_version;
+
 /* An string containing the version information of the library. */
 FRIBIDI_ENTRY const char *fribidi_version_info;
 


### PR DESCRIPTION
Resolves https://github.com/fribidi/fribidi/issues/109

I can't actually test on this machine to verify it solves the issue, so if someone else quickly could that would be fantastic (@moham96?).

To ensure issues like this don't crop up in the future it would probably be best to pass `-fvisibility=hidden` to autotools builds as well, but I think that's best addressed by someone more familiar with it than I.