### PR TITLE
Use LDFLAGS_FOR_BUILD for cross-compilation

### DIFF
--- a/gen.tab/Makefile.am
+++ b/gen.tab/Makefile.am
@@ -26,6 +26,7 @@ gen_brackets_type_tab_CPPFLAGS = $(AM_CPPFLAGS)
 CFLAGS_FOR_BUILD += -DHAVE_CONFIG_H -I$(top_builddir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
 CC = $(CC_FOR_BUILD)
 CFLAGS = $(CFLAGS_FOR_BUILD)
+LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 CLEANFILES = $(EXTRA_PROGRAMS)
 DISTCLEANFILES =


### PR DESCRIPTION
Otherwise the regular LDFLAGS can wreak havoc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fribidi/fribidi/115)
<!-- Reviewable:end -->
