### PR TITLE
Bump the version in meson.build too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('fribidi', 'c', version: '1.0.5',
+project('fribidi', 'c', version: '1.0.6',
   meson_version : '>= 0.44')
 
 # New release:


### PR DESCRIPTION
Apparently missing bumping the version in meson.build