### PR TITLE
meson: allow to disable building tests and binaries

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -84,8 +84,12 @@ incs = include_directories('.', 'lib', 'gen.tab')
 
 subdir('gen.tab')
 subdir('lib')
-subdir('bin')
-subdir('test')
+if get_option('bin')
+  subdir('bin')
+endif
+if get_option('tests')
+   subdir('test')
+endif
 if get_option('docs')
   subdir('doc')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,7 @@ option('deprecated', type : 'boolean', value : true,
   description: 'Build deprecated functionality')
 option('docs', type : 'boolean', value : true,
   description: 'Build documentation')
+option('bin', type : 'boolean', value : true,
+  description: 'Build binaries')
+option('tests', type : 'boolean', value : true,
+  description: 'Build tests')


### PR DESCRIPTION
This allows to optionally not build tests, nor binaries.