### PR TITLE
meson: Use the `debug` option directly instead of `buildtype`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('fribidi', 'c', version: '1.0.9',
-  meson_version : '>= 0.44')
+  meson_version : '>= 0.48')
 
 # New release:
 #   interface_age++
@@ -69,8 +69,7 @@ endif
 # This is available pretty much everywhere
 cdata.set('HAVE_STRINGIZE', 1)
 
-buildtype = get_option('buildtype')
-if buildtype == 'debug' or buildtype == 'debugoptimized'
+if get_option('debug')
   cdata.set('DEBUG', 1)
 endif
 


### PR DESCRIPTION
`get_option('buildtype')` returns `'custom'` in most of the cases
where `-Ddebug` is set. However, `get_option('debug')` will always be
set correctly if the user sets `-Dbuildtype`. See the following table
for the mapping:

https://mesonbuild.com/Builtin-options.html#build-type-options