### PR TITLE
Fix FRIBIDI_ENTRY on Windows

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -9,6 +9,7 @@ fribidi_SOURCES = fribidi-main.c $(getopt_SOURCES)
 fribidi_benchmark_SOURCES = fribidi-benchmark.c $(getopt_SOURCES)
 
 AM_CPPFLAGS = \
+		@FRIBIDI_CPPFLAGS@ \
 		-I$(top_builddir)/lib \
 		-I$(top_srcdir)/lib
 

--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,27 +1,27 @@
 fribidi = executable('fribidi',
   'fribidi-main.c', 'getopt.c', 'getopt1.c', fribidi_unicode_version_h,
-  c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+  c_args: ['-DHAVE_CONFIG_H'] + fribidi_static_cargs + visibility_args,
   include_directories: incs,
   link_with: libfribidi,
   install: true)
 
 executable('fribidi-benchmark',
   'fribidi-benchmark.c', 'getopt.c', 'getopt1.c', fribidi_unicode_version_h,
-  c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+  c_args: ['-DHAVE_CONFIG_H'] + fribidi_static_cargs + visibility_args,
   include_directories: incs,
   link_with: libfribidi,
   install: false)
 
 executable('fribidi-bidi-types',
   'fribidi-bidi-types.c', fribidi_unicode_version_h,
-  c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+  c_args: ['-DHAVE_CONFIG_H'] + fribidi_static_cargs + visibility_args,
   include_directories: incs,
   link_with: libfribidi,
   install: false)
 
 executable('fribidi-caprtl2utf8',
   'fribidi-caprtl2utf8.c', fribidi_unicode_version_h,
-  c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+  c_args: ['-DHAVE_CONFIG_H'] + fribidi_static_cargs + visibility_args,
   include_directories: incs,
   link_with: libfribidi,
   install: false)

--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,13 @@ if test x$enable_deprecated = xno; then
 		  [Don not build deprecated functionality])
 fi
 
+# define FRIBIDI_LIB_STATIC if in static mode
+if test "$enable_static" = "yes" ; then
+	FRIBIDI_CPPFLAGS="-DFRIBIDI_LIB_STATIC"
+fi
+AC_SUBST(FRIBIDI_CPPFLAGS)
+
+
 # Generate output
 AC_CONFIG_FILES([fribidi.pc
 		 lib/fribidi-config.h

--- a/fribidi.pc.in
+++ b/fribidi.pc.in
@@ -10,3 +10,4 @@ Description: Unicode Bidirectional Algorithm Library
 Version: @VERSION@
 Libs: -L${libdir} -lfribidi
 Cflags: -I${includedir}/@PACKAGE@
+CFLAGS.private: -DFRIBIDI_LIB_STATIC

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,9 +8,7 @@ libfribidi_la_LDFLAGS = -no-undefined -version-info $(LT_VERSION_INFO)
 libfribidi_la_LIBADD =
 libfribidi_la_DEPENDENCIES =
 
-if OS_WIN32
-libfribidi_la_LDFLAGS += -export-symbols $(srcdir)/fribidi.def
-else
+if !OS_WIN32
 libfribidi_la_LDFLAGS += -export-symbols-regex "^fribidi_.*"
 endif # OS_WIN32
 
@@ -55,6 +53,8 @@ libfribidi_la_SOURCES =	\
 		brackets.tab.i \
 		brackets-type.tab.i \
 		run.h
+
+libfribidi_la_CPPFLAGS = @FRIBIDI_CPPFLAGS@ -DFRIBIDI_BUILD
 
 GENERATEDSOURCES = \
 		fribidi-unicode-version.h \

--- a/lib/fribidi-bidi-types.h
+++ b/lib/fribidi-bidi-types.h
@@ -377,7 +377,7 @@ fribidi_get_bidi_type (
  * fribidi_get_bidi_type() for more information about the bidi types returned
  * by this function.
  */
-     FRIBIDI_ENTRY void fribidi_get_bidi_types (
+FRIBIDI_ENTRY void fribidi_get_bidi_types (
   const FriBidiChar *str,	/* input string */
   const FriBidiStrIndex len,	/* input string length */
   FriBidiCharType *btypes	/* output bidi types */

--- a/lib/fribidi-bidi.h
+++ b/lib/fribidi-bidi.h
@@ -118,7 +118,7 @@ fribidi_get_par_embedding_levels_ex (
  * Returns: Maximum level found in this line plus one, or zero if any error
  * occurred (memory allocation failure most probably).
  */
-     FRIBIDI_ENTRY FriBidiLevel fribidi_reorder_line (
+FRIBIDI_ENTRY FriBidiLevel fribidi_reorder_line (
   FriBidiFlags flags, /* reorder flags */
   const FriBidiCharType *bidi_types,	/* input list of bidi types as returned by
 					   fribidi_get_bidi_types() */

--- a/lib/fribidi-common.h
+++ b/lib/fribidi-common.h
@@ -42,19 +42,27 @@
 
 
 /* FRIBIDI_ENTRY is a macro used to declare library entry points. */
-#ifndef FRIBIDI_ENTRY
-# if (defined(_MSC_VER) || defined(FRIBIDI_BUILT_WITH_MSVC)) && !defined(FRIBIDI_STATIC)
-/* if we're building fribidi itself with MSVC, FRIBIDI_ENTRY will be defined,
- * so if we're here then this is an external user including fribidi headers.
- * The dllimport is needed here mostly for the fribidi_version_info variable,
- * for functions it's not required. Probably needs more fine-tuning if
- * someone starts building fribidi as static library with MSVC. We'll cross
- * that bridge when we get there. */
-#  define FRIBIDI_ENTRY __declspec(dllimport) extern
+#ifndef FRIBIDI_LIB_STATIC
+# ifdef _WIN32
+#  ifdef FRIBIDI_BUILD
+#    define FRIBIDI_ENTRY __declspec(dllexport)
+#  else
+#    define FRIBIDI_ENTRY __declspec(dllimport)
+#  endif
+# elif (defined(__SUNPRO_C)  || defined(__SUNPRO_CC))
+#  define FRIBIDI_ENTRY __global
 # else
-#  define FRIBIDI_ENTRY extern
+#  if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__ICC)
+#    define FRIBIDI_ENTRY __attribute__ ((visibility("default")))
+#  else
+#   define FRIBIDI_ENTRY
+#  endif
 # endif
-#endif /* !FRIBIDI_ENTRY */
+#else
+# define FRIBIDI_ENTRY
+#endif
+
+#define FRIBIDI_EXTERN extern
 
 #ifdef __ICC
 #define FRIBIDI_BEGIN_IGNORE_DEPRECATIONS               \
@@ -85,7 +93,7 @@
 #define FRIBIDI_END_IGNORE_DEPRECATIONS
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ > 2)
+#if (defined(__GNUC__) && (__GNUC__ > 2)) && ! defined(_WIN32)
 # define FRIBIDI_GNUC_WARN_UNUSED __attribute__((__warn_unused_result__))
 # define FRIBIDI_GNUC_MALLOC      __attribute__((__malloc__))
 # define FRIBIDI_GNUC_HIDDEN      __attribute__((__visibility__ ("hidden")))

--- a/lib/fribidi-common.h
+++ b/lib/fribidi-common.h
@@ -59,7 +59,9 @@
 #  endif
 # endif
 #else
-# define FRIBIDI_ENTRY
+# ifndef FRIBIDI_ENTRY
+#   define FRIBIDI_ENTRY
+# endif
 #endif
 
 #define FRIBIDI_EXTERN extern

--- a/lib/fribidi-deprecated.h
+++ b/lib/fribidi-deprecated.h
@@ -41,7 +41,7 @@
  *
  * This function is deprecated and only used with other deprecated functions.
  */
-     FRIBIDI_ENTRY fribidi_boolean fribidi_mirroring_status (
+FRIBIDI_ENTRY fribidi_boolean fribidi_mirroring_status (
   void
 ) FRIBIDI_GNUC_DEPRECATED;
 
@@ -59,7 +59,7 @@
  *
  * Returns: the new mirroring status.
  */
-     FRIBIDI_ENTRY fribidi_boolean fribidi_set_mirroring (
+FRIBIDI_ENTRY fribidi_boolean fribidi_set_mirroring (
   fribidi_boolean state		/* new state to set */
 ) FRIBIDI_GNUC_DEPRECATED;
 
@@ -68,7 +68,7 @@
  *
  * This function is deprecated and only used with other deprecated functions.
  */
-     FRIBIDI_ENTRY fribidi_boolean fribidi_reorder_nsm_status (
+FRIBIDI_ENTRY fribidi_boolean fribidi_reorder_nsm_status (
   void
 ) FRIBIDI_GNUC_DEPRECATED;
 
@@ -88,7 +88,7 @@
  *
  * Returns: the new marks reordering status.
  */
-     FRIBIDI_ENTRY fribidi_boolean fribidi_set_reorder_nsm (
+FRIBIDI_ENTRY fribidi_boolean fribidi_set_reorder_nsm (
   fribidi_boolean state		/* new state to set */
 ) FRIBIDI_GNUC_DEPRECATED;
 

--- a/lib/fribidi-joining-types.h
+++ b/lib/fribidi-joining-types.h
@@ -222,7 +222,7 @@ fribidi_get_joining_type (
  * fribidi_get_joining_type for more information about the joining types
  * returned by this function.
  */
-     FRIBIDI_ENTRY void fribidi_get_joining_types (
+FRIBIDI_ENTRY void fribidi_get_joining_types (
   const FriBidiChar *str,	/* input string */
   const FriBidiStrIndex len,	/* input string length */
   FriBidiJoiningType *jtypes	/* output joining types */
@@ -237,7 +237,7 @@ fribidi_get_joining_type (
  * Joining Classes of the Unicode standard available at
  * http://www.unicode.org/versions/Unicode4.0.0/ch08.pdf#G7462.
  */
-     FRIBIDI_ENTRY const char *fribidi_get_joining_type_name (
+FRIBIDI_ENTRY const char *fribidi_get_joining_type_name (
   FriBidiJoiningType j		/* input joining type */
 ) FRIBIDI_GNUC_CONST;
 

--- a/lib/fribidi-unicode.h
+++ b/lib/fribidi-unicode.h
@@ -45,7 +45,7 @@
 
 /* An string containing the version the Unicode standard implemented,
  * in the form of "x.y.z", or "unknown". */
-FRIBIDI_ENTRY const char *fribidi_unicode_version;
+FRIBIDI_ENTRY FRIBIDI_EXTERN const char *fribidi_unicode_version;
 
 
 /* Unicode Bidirectional Algorithm definitions: */

--- a/lib/fribidi.h
+++ b/lib/fribidi.h
@@ -119,7 +119,7 @@ FRIBIDI_ENTRY FriBidiLevel fribidi_log2vis (
 
 
 /* An string containing the version information of the library. */
-FRIBIDI_ENTRY const char *fribidi_version_info;
+FRIBIDI_ENTRY FRIBIDI_EXTERN const char *fribidi_version_info;
 
 #include "fribidi-enddecls.h"
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -75,7 +75,7 @@ libfribidi = library('fribidi',
   fribidi_sources, fribidi_unicode_version_h, fribidi_config_h,
   generated_tab_include_files, config_h,
   include_directories: incs,
-  c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+  c_args: ['-DHAVE_CONFIG_H', '-DFRIBIDI_BUILD'] + fribidi_static_cargs + visibility_args,
   version: libversion,
   soversion: soversion,
   install: true)

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ endif
 visibility_args = []
 fribidi_static_cargs = []
 if have_visibility_hidden
-  visibility_args = ['-DFRIBIDI_ENTRY=extern __attribute__ ((visibility ("default")))']
+  visibility_args = ['-DFRIBIDI_ENTRY=__attribute__ ((visibility ("default")))']
 else
   if host_machine.system() == 'windows'
     if get_option('default_library') == 'static'

--- a/meson.build
+++ b/meson.build
@@ -26,19 +26,24 @@ if cc.get_id() == 'gcc' and cc.has_argument('-ansi')
 endif
 
 # Symbol visibility
-have_visibility_hidden = cc.has_argument('-fvisibility=hidden')
-if have_visibility_hidden
-  add_project_arguments('-fvisibility=hidden', language: 'c')
+have_visibility_hidden = false
+if host_machine.system() != 'windows'
+  have_visibility_hidden = cc.has_argument('-fvisibility=hidden')
+  if have_visibility_hidden
+    add_project_arguments('-fvisibility=hidden', language: 'c')
+  endif
 endif
 
 # Must explicitly make symbols public if default visibility is hidden
+visibility_args = []
+fribidi_static_cargs = []
 if have_visibility_hidden
   visibility_args = ['-DFRIBIDI_ENTRY=extern __attribute__ ((visibility ("default")))']
 else
-  if host_machine.system() == 'windows' and get_option('default_library') != 'static'
-    visibility_args = ['-DFRIBIDI_ENTRY=__declspec(dllexport)']
-  else
-    visibility_args = ['-DFRIBIDI_ENTRY=extern']
+  if host_machine.system() == 'windows'
+    if get_option('default_library') == 'static'
+      fribidi_static_cargs = ['-DFRIBIDI_LIB_STATIC']
+    endif
   endif
 endif
 

--- a/test/unicode-conformance/Makefile.am
+++ b/test/unicode-conformance/Makefile.am
@@ -15,6 +15,7 @@ TEST_DATAS = \
 TXT_LOG_COMPILER = sh $(srcdir)/run.tests
 
 AM_CPPFLAGS = \
+		@FRIBIDI_CPPFLAGS@ \
 		-I$(top_builddir)/lib \
 		-I$(top_srcdir)/lib \
 		-I$(top_srcdir)/charset

--- a/test/unicode-conformance/meson.build
+++ b/test/unicode-conformance/meson.build
@@ -5,7 +5,7 @@ tests = [
 foreach t : tests
   exe = executable(t[0],
     t[1], fribidi_unicode_version_h,
-    c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+    c_args: ['-DHAVE_CONFIG_H'] + fribidi_static_cargs + visibility_args,
     include_directories: incs,
     link_with: libfribidi)
   test(t[0], exe, args: files('@0@.txt'.format(t[0])))


### PR DESCRIPTION
 * when the shared library is compiled, it is set to dllexport
 * when the shared library is used, it is set to dllimport
 * when the static library is used, it is set to nothing
   (FRIBIDI_LIB_STATIC must be passed to the preprocessor)
 * Cflags.private is set to -DFRIBIDI_LIB_STATIC in fribidi.pc (used
   with pkgconf)