### PR TITLE
meson: add fribidi_static_cargs to extra_cflags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -103,6 +103,7 @@ pkg = import('pkgconfig')
 pkg.generate(name: 'GNU FriBidi',
   filebase: 'fribidi',
   description: 'Unicode Bidirectional Algorithm Library',
-  libraries: libfribidi, 
+  libraries: libfribidi,
+  extra_cflags: fribidi_static_cargs,
   subdirs: 'fribidi',
   version: meson.project_version())


### PR DESCRIPTION
meson seemingly doesn't have a section for cflags.private, so the flags will have to go to the regular cflags for now
it can be replaced by manual sed or similar to append that line if wanted

Fixes m-ab-s/media-autobuild_suite#1735
Fixes https://github.com/fribidi/fribidi/issues/156