### PR TITLE
Don't decrease isolate level if is already zero

### DIFF
--- a/lib/fribidi-bidi.c
+++ b/lib/fribidi-bidi.c
@@ -698,7 +698,7 @@ fribidi_get_par_embedding_levels_ex (
                   RL_LEVEL (pp) = level;
                 }
 
-              else if (valid_isolate_count > 0)
+              else if (valid_isolate_count > 0 && isolate_level != 0)
                 {
                   /* Pop away all LRE,RLE,LRO, RLO levels
                      from the stack, as these are implicitly


### PR DESCRIPTION
Fixes https://crbug.com/oss-fuzz/34695

Without it we have -1 `isolate_level` which means we are indexing -1 on https://github.com/fribidi/fribidi/blob/master/lib/fribidi-bidi.c#L816

This probably can have a better and more fundamental solution, feel free to give your idea or just apply it right away and close this.

To reproduce: 
1. Download the case
2. Run the following,
```
CC=clang CC_LD=lld CFLAGS="-fsanitize=memory,fuzzer-no-link" meson msanbuild --default-library=static -Dfuzzer_ldflags="-fsanitize=memory,fuzzer" -Ddocs=false
ninja -Cmsanbuild
msanbuild/bin/fribidi-fuzzer clusterfuzz-testcase-minimized-fribidi-fuzzer-5361146803650560
```