### PR TITLE
Open GitHub CI: build with make

### DIFF
--- a/.ci/build-c2man.sh
+++ b/.ci/build-c2man.sh
@@ -4,10 +4,10 @@ git clone https://github.com/fribidi/c2man.git
 cd c2man
 
 ./Configure -dE
-mkdir -p $TRAVIS_BUILD_DIR/c2man-install
-echo "binexp=$TRAVIS_BUILD_DIR/c2man-install" >> config.sh
-echo "installprivlib=$TRAVIS_BUILD_DIR/c2man-install" >> config.sh
-echo "mansrc=$TRAVIS_BUILD_DIR/c2man-install" >> config.sh
+mkdir -p $(pwd)/c2man-install
+echo "binexp=$(pwd)/c2man-install" >> config.sh
+echo "installprivlib=$(pwd)/c2man-install" >> config.sh
+echo "mansrc=$(pwd)/c2man-install" >> config.sh
 sh config_h.SH
 sh flatten.SH
 sh Makefile.SH

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -12,12 +12,13 @@ jobs:
     strategy: 
       matrix:
         os: [ubuntu-latest]
-        compiler: [gcc]
-        install: bash .ci/build-c2man.sh
-        env: PATH=$PATH:$TRAVIS_BUILD_DIR/c2man-install
+        compiler: [gcc]    
 
+    env: PATH=$PATH:$(pwd)/fribidi/c2man/c2man-install
     steps:
     - uses: actions/checkout@v2
+    - name: build c2man
+      run: bash .ci/build-c2man.sh
     - name: configure
       run: ./autogen.sh
     - run: make

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,25 @@
+name: Build with make
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy: 
+      matrix:
+        os: [ubuntu-latest]
+        compiler: [gcc]
+        install: bash .ci/build-c2man.sh
+        env: PATH=$PATH:$TRAVIS_BUILD_DIR/c2man-install
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./autogen.sh
+    - run: make
+    - run: make check
+    - run: make distcheck

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -14,8 +14,8 @@ jobs:
         os: [ubuntu-latest]
         compiler: [gcc]    
 
-    env: PATH=$PATH:$(pwd)/fribidi/c2man/c2man-install
     steps:
+    - run: PATH=$PATH:$(pwd)/fribidi/c2man/c2man-install
     - uses: actions/checkout@v2
     - name: build c2man
       run: bash .ci/build-c2man.sh


### PR DESCRIPTION
Should we remove `.travis.yml`, `appveyor.yml`?

----

**Why not add `macos-latest` into `matrix.os`?**

`macos-latest` == `macos-10.15`, with Clang/LLVM 12.0.0, it compiles with newer c standard  by default. And then we have errors.

> By default, Clang builds C code in GNU C17 mode
> 
> [Language Compatibility](https://clang.llvm.org/compatibility.html#inline)

Maybe we need to set some old `-std` version, or use old clang, or update c2man code, or replace c2man with something new.

Several attempts: https://github.com/Aeg-dev/c2man/commits/test-ci