### PR TITLE
Fix the heap buffer overflow in fribidi_cap_rtl_to_unicode

### DIFF
--- a/lib/fribidi-char-sets-cap-rtl.c
+++ b/lib/fribidi-char-sets-cap-rtl.c
@@ -232,7 +232,12 @@ fribidi_cap_rtl_to_unicode (
 	    }
 	}
       else
-	us[j++] = caprtl_to_unicode[(int) s[i]];
+	{
+	  if (s[i] >= 0 && s[i] < CAPRTL_CHARS)
+	    us[j++] = caprtl_to_unicode[(int) s[i]];
+	  else
+	    us[j++] = s[i];
+	}
     }
 
   return j;


### PR DESCRIPTION
CapRTL charset is represented in ASCII range 1-127.
but an input to caprtl_to_unicode may be possibly more than that.

AddressSanitizer reports this like:
=================================================================
==1223446==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6150000002fc at pc 0x7fb94f3409fc bp 0x7ffca618
7190 sp 0x7ffca6187188
READ of size 4 at 0x6150000002fc thread T0
    #0 0x7fb94f3409fb in fribidi_cap_rtl_to_unicode ../lib/fribidi-char-sets-cap-rtl.c:235
    #1 0x402bda in main ../bin/fribidi-main.c:403
    #2 0x7fb94f15d58f in __libc_start_call_main (/lib64/libc.so.6+0x2d58f)
    #3 0x7fb94f15d648 in __libc_start_main_impl (/lib64/libc.so.6+0x2d648)
    #4 0x403714 in _start (/tmp/fribidi/build/bin/fribidi+0x403714)

0x6150000002fc is located 4 bytes to the left of 512-byte region [0x615000000300,0x615000000500)
allocated by thread T0 here:
    #0 0x7fb94f41d81f in __interceptor_malloc (/lib64/libasan.so.8+0xba81f)
    #1 0x7fb94f340025 in init_cap_rtl ../lib/fribidi-char-sets-cap-rtl.c:87
    #2 0x7fb94f3409e0 in fribidi_cap_rtl_to_unicode ../lib/fribidi-char-sets-cap-rtl.c:180
    #3 0x402bda in main ../bin/fribidi-main.c:403
    #4 0x7fb94f15d58f in __libc_start_call_main (/lib64/libc.so.6+0x2d58f)

So such input needs to be ignored.

This fixes https://github.com/fribidi/fribidi/issues/182