### PR TITLE
Add -DFRIBIDI_LIB_STATIC to libfribidi_dep

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -82,4 +82,5 @@ libfribidi = library('fribidi',
 
 libfribidi_dep = declare_dependency(link_with: libfribidi,
   include_directories: incs,
-  sources: [fribidi_unicode_version_h, fribidi_config_h])
+  sources: [fribidi_unicode_version_h, fribidi_config_h],
+  compile_args: fribidi_static_cargs)


### PR DESCRIPTION
It is needed when fribidi is used as subproject and is static linked on
Windows. The pkg-config file already contains it for the same reason.