### PR TITLE
meson: Override dependencies to improve usage as a subproject

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -30,3 +30,9 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: fribidi-*.tar.xz
+
+    - name: 'Upload build logs'
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        path: test/test-suite.log

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -46,3 +46,8 @@ jobs:
       run: ninja -C build
     - name: ninja test
       run: ninja -C build test
+    - name: 'Upload build logs'
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        path: build/meson-logs/*

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -13,12 +13,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         compiler: [gcc]
-        python-version: [3.6]
+        python-version: [3.8]
         include:
         ## test with MSVC
         - os: windows-latest
           compiler: msvc
-          python-version: 3.6
+          python-version: 3.8
           msvc: true
 
     steps:

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -84,3 +84,4 @@ libfribidi_dep = declare_dependency(link_with: libfribidi,
   include_directories: incs,
   sources: [fribidi_unicode_version_h, fribidi_config_h],
   compile_args: fribidi_static_cargs)
+meson.override_dependency('fribidi', libfribidi_dep)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('fribidi', 'c', version: '1.0.12',
-  meson_version : '>= 0.48')
+  meson_version : '>= 0.54')
 
 # New release:
 #   interface_age++


### PR DESCRIPTION
With this change, fribidi can be consumed as a subproject without making any changes to the build files of a project. All you need to do is provide a wrap file with a `[provide]` section:

https://mesonbuild.com/Wrap-dependency-system-manual.html#provide-section

This is also necessary because otherwise projects need to hard-code the subproject name, which might be `fribidi` when using `wrap-git` or `fribidi-1.0.12` when using `wrap-file` (to build from a release tarball). This can cause conflicts between different subprojects that consume fribidi differently.

Other projects like glib, cairo, pango, etc already do this.

Bumped the minimum version of Meson to 0.54 because that's the release that added this feature. It was released almost three years ago, so should be fine.