### PR TITLE
meson: fix build with -Dbin=false and -Dtests=true

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,9 +1,15 @@
+# The fribidi binary is used by the test setup, so if bin=false we still
+# need to build it for internal usage, we just won't install it.
 fribidi = executable('fribidi',
   'fribidi-main.c', 'getopt.c', 'getopt1.c', fribidi_unicode_version_h,
   c_args: ['-DHAVE_CONFIG_H'] + fribidi_static_cargs,
   include_directories: incs,
   link_with: libfribidi,
-  install: true)
+  install: get_option('bin'))
+
+if not get_option('bin')
+  subdir_done()
+endif
 
 executable('fribidi-benchmark',
   'fribidi-benchmark.c', 'getopt.c', 'getopt1.c', fribidi_unicode_version_h,

--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,7 @@ incs = include_directories('.', 'lib', 'gen.tab')
 
 subdir('gen.tab')
 subdir('lib')
-if get_option('bin')
+if get_option('bin') or get_option('tests')
   subdir('bin')
 endif
 if get_option('tests')


### PR DESCRIPTION
The fribidi binary is needed by the unit test setup, so if tests are enabled we need to build it even if binaries are disabled. We just won't install it in that case.

Fixes #198