### PR TITLE
debug: don't pass a comma "," in a #define

### DIFF
--- a/lib/debug.h
+++ b/lib/debug.h
@@ -48,29 +48,29 @@
 #  include <stdio.h>
 # endif	/* !__FRIBIDI_DOC */
 # define FRIBIDI_FPRINTF fprintf
-# define FRIBIDI_STDERR_ stderr,
+# define FRIBIDI_STDERR stderr
 #endif /* !FRIBIDI_FPRINTF */
 
 #ifndef MSG
 #define MSG(s) \
 	FRIBIDI_BEGIN_STMT \
-	FRIBIDI_FPRINTF(FRIBIDI_STDERR_ s); \
+	FRIBIDI_FPRINTF(FRIBIDI_STDERR, s); \
 	FRIBIDI_END_STMT
 #define MSG2(s, t) \
 	FRIBIDI_BEGIN_STMT \
-	FRIBIDI_FPRINTF(FRIBIDI_STDERR_ s, t); \
+	FRIBIDI_FPRINTF(FRIBIDI_STDERR, s, t); \
 	FRIBIDI_END_STMT
 #define MSG3(s, t, u) \
 	FRIBIDI_BEGIN_STMT \
-	FRIBIDI_FPRINTF(FRIBIDI_STDERR_ s, t, u); \
+	FRIBIDI_FPRINTF(FRIBIDI_STDERR, s, t, u); \
 	FRIBIDI_END_STMT
 #define MSG5(s, t, u, v, w) \
 	FRIBIDI_BEGIN_STMT \
-	FRIBIDI_FPRINTF(FRIBIDI_STDERR_ s, t, u, v, w); \
+	FRIBIDI_FPRINTF(FRIBIDI_STDERR, s, t, u, v, w); \
 	FRIBIDI_END_STMT
 #define MSG6(s, t, u, v, w, z)                    \
 	FRIBIDI_BEGIN_STMT \
-	FRIBIDI_FPRINTF(FRIBIDI_STDERR_ s, t, u, v, w, z);        \
+	FRIBIDI_FPRINTF(FRIBIDI_STDERR, s, t, u, v, w, z);        \
 	FRIBIDI_END_STMT
 #endif /* !MSG */
 


### PR DESCRIPTION
Clang does not accept that, and errors out like so:

../../../../pexip/external/fribidi/lib/fribidi.c:84:3: error: expected expression
  DBG ("in fribidi_remove_bidi_marks");
  ^
../../../../pexip/external/fribidi/lib/debug.h:84:32: note: expanded from macro 'DBG'
        if (fribidi_debug_status()) { MSG(FRIBIDI ": " s "\n"); } \
                                      ^
../../../../pexip/external/fribidi/lib/debug.h:57:2: note: expanded from macro 'MSG'
        FRIBIDI_FPRINTF(FRIBIDI_STDERR_ s); \
        ^
../../../../pexip/external/fribidi/lib/debug.h:50:26: note: expanded from macro 'FRIBIDI_FPRINTF' # define FRIBIDI_FPRINTF fprintf
                         ^
/usr/include/x86_64-linux-gnu/bits/stdio2.h:113:62: note: expanded from macro 'fprintf'
  __fprintf_chk (stream, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)