### PR TITLE
meson: remove -ansi flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,10 +21,6 @@ libversion = '@0@.@1@.0'.format(soversion, interface_version, interface_age)
 # C compiler. This is the cross compiler if we're cross-compiling
 cc = meson.get_compiler('c')
 
-if cc.get_id() == 'gcc' and cc.has_argument('-ansi')
-  add_project_arguments('-ansi', language: 'c')
-endif
-
 # Handle symbol visibility for Windows
 fribidi_static_cargs = []
 fribidi_build_cargs = []


### PR DESCRIPTION
This PR is intended to support issue #153.
As @elahav said in his issue ticket, `-ansi` will flag `-std=c90` and it is very outdated.
It is probably a better idea to leave this option to the user rather than an enforcement.