### PR TITLE
Stack buffer overflow via CapRTL output expansion

### DIFF
--- a/bin/fribidi-main.c
+++ b/bin/fribidi-main.c
@@ -382,7 +382,7 @@ FRIBIDI_END_IGNORE_DEPRECATIONS
 	  {
 	    const char *new_line, *nl_found;
 	    FriBidiChar logical[MAX_STR_LEN];
-	    char outstring[MAX_STR_LEN];
+	    char outstring[4 * MAX_STR_LEN + 1];
 	    FriBidiParType base;
 	    FriBidiStrIndex len;
 


### PR DESCRIPTION
Size `outstring` for the worst-case encoding scenario (CapRTL ×2, UTF-8 ×4, +NUL).

### Proof of Concept

```sh
python3 -c "import sys; sys.stdout.buffer.write(b'\x14' * 40000)" > poc.txt
./bin/fribidi --caprtl --nobreak poc.txt
```
```
==130617==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffdd4ecead8
WRITE of size 1 at 0x7ffdd4ecead8 thread T0
    #0 0x5975c50c962c in fribidi_unicode_to_cap_rtl  lib/fribidi-char-sets-cap-rtl.c:263
    #1 0x5975c50c7f57 in fribidi_unicode_to_charset  lib/fribidi-char-sets.c:183
    #2 0x5975c50be815 in main                        bin/fribidi-main.c:479

  This frame has 5 object(s):
    [325584, 390584) 'outstring' (line 385) <== Memory access at offset 390584 overflows this variable
SUMMARY: AddressSanitizer: stack-buffer-overflow lib/fribidi-char-sets-cap-rtl.c:263 in fribidi_unicode_to_cap_rtl
```