### PR TITLE
ci: add permissions and pin action SHAs

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,7 +17,7 @@ jobs:
         compiler: [gcc]    
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
     - name: build c2man
       run: bash .ci/build-c2man.sh
     - run: echo "$GITHUB_WORKSPACE/c2man/c2man-install" >> $GITHUB_PATH
@@ -27,19 +29,19 @@ jobs:
     - run: make distcheck
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         path: fribidi-*.tar.xz
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       if: failure()
       with:
         path: test/test-suite.log
 
     - name: Upload test-suite.log
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: test-suite-log
         path: test/test-suite.log

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -22,7 +24,7 @@ jobs:
           msvc: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
     - name: Setup MSVC
       if: matrix.os == 'windows-latest' && matrix.msvc == true
@@ -30,7 +32,7 @@ jobs:
     
     ## Shared build steps
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up meson
@@ -47,7 +49,7 @@ jobs:
     - name: ninja test
       run: ninja -C build test
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       if: failure()
       with:
         path: build/meson-logs/*


### PR DESCRIPTION
## Summary

The CI workflows are missing top-level \`permissions\` declarations and reference actions by mutable version tags, which are supply-chain risk vectors.

**Changes:**
- Add \`permissions: read-all\` at the workflow level for all workflows (least-privilege default)
- Pin all third-party action references to full commit SHAs

Mutable action references (\`@v4\`, \`@main\`, etc.) allow a compromised upstream action to run arbitrary code in your CI. Pinning to a commit SHA ensures only the audited version runs.