### PR TITLE
Remove unnecessary custom prototypes for getenv and getopt

### DIFF
--- a/bin/getopt.c
+++ b/bin/getopt.c
@@ -50,13 +50,13 @@
 
 #ifndef ELIDE_CODE
 
+#include <stdlib.h>
 
 /* This needs to come after some library #include
    to get __GNU_LIBRARY__ defined.  */
 #ifdef	__GNU_LIBRARY__
-/* Don't include stdlib.h for non-GNU C libraries because some of them
+/* Don't include unistd.h for non-GNU C libraries because some of them
    contain conflicting prototypes for getopt.  */
-# include <stdlib.h>
 # include <unistd.h>
 #endif /* GNU C library.  */
 
@@ -137,18 +137,6 @@ int optopt = '?';
 static struct _getopt_data getopt_data;
 
 
-#ifndef __GNU_LIBRARY__
-
-/* Avoid depending on library functions or files
-   whose names are inconsistent.  */
-
-#ifndef getenv
-extern char *getenv (
-);
-#endif
-
-#endif /* not __GNU_LIBRARY__ */
-
 #ifdef _LIBC
 /* Stored original parameters.
    XXX This is no good solution.  We should rather copy the args so

--- a/bin/getopt.h
+++ b/bin/getopt.h
@@ -145,20 +145,6 @@ extern "C"
    arguments to the option '\0'.  This behavior is specific to the GNU
    `getopt'.  */
 
-#ifdef __GNU_LIBRARY__
-/* Many other libraries have conflicting prototypes for getopt, with
-   differences in the consts, in stdlib.h.  To avoid compilation
-   errors, only prototype getopt for the GNU C library.  */
-  extern int getopt (
-  int ___argc,
-  char *const *___argv,
-  const char *__shortopts
-  ) __THROW;
-#else				/* not __GNU_LIBRARY__ */
-  extern int getopt (
-  );
-#endif				/* __GNU_LIBRARY__ */
-
 #ifndef __need_getopt
   extern int getopt_long (
   int ___argc,


### PR DESCRIPTION
Include `<stdlib.h>` in windows environments, to fix windows build.

Closes #220.