### PR TITLE
Pair brackets by canonical equivalence only, per UAX #9 BD16 (fixes #233)

### DIFF
--- a/gen.tab/gen-brackets-tab.c
+++ b/gen.tab/gen-brackets-tab.c
@@ -156,7 +156,7 @@ read_unicode_data_txt_equivalence (
       const char *s = buf;
       char ce_string[256]; /* For parsing the equivalence */
       char *p = NULL;
-      int ce, in_tag;
+      int ce;
 
       l++;
 
@@ -175,26 +175,33 @@ read_unicode_data_txt_equivalence (
       if (i==1)
         continue;
 
-      /* split and parse ce */
+      /* Parse the decomposition mapping (field 5).  UAX #9 BD16 pairs
+       * brackets using canonical equivalence only, so a compatibility
+       * decomposition -- the ones introduced by a "<tag>" prefix -- must
+       * not feed the bracket table.  Otherwise the fullwidth form U+FF08
+       * would be folded to its ASCII counterpart U+0028 and the two would
+       * wrongly pair with each other. */
       p = ce_string;
+      while (*p == ' ')
+        p++;
+      if (*p == '<')
+        continue;
+
       ce = -1;
-      in_tag = 0;
-      while(*p)
+      while (*p)
         {
-          if (*p==';')
+          if (*p == ';')
             break;
-          else if (*p=='<')
-            in_tag = 1;
-          else if (*p=='>')
-            in_tag = 0;
-          else if (!in_tag && isalnum(*p))
+          else if (isalnum (*p))
             {
               /* Assume we got a hexa decimal */
-              ce = strtol(p,NULL,16);
+              ce = strtol (p, NULL, 16);
               break;
             }
           p++;
         }
+      if (ce < 0)
+        continue;
 
       /* FIXME: We don't handle First..Last parts of UnicodeData.txt,
        * but it works, since all those are LTR. */


### PR DESCRIPTION
Fixes #233.

## Root cause
The bracket-table generator (`gen.tab/gen-brackets-tab.c`, `read_unicode_data_txt_equivalence`) reads a character's decomposition mapping (field 5 of `UnicodeData.txt`) and folds the partner bracket to that value, but it does not skip compatibility (`<tag>`) decompositions -- it only stepped over the tag text and then read the hex that followed. UAX #9 BD16 pairs brackets using canonical equivalence only. As a result the fullwidth forms U+FF08 / U+FF09 (`<wide> 0028` / `<wide> 0029`) were made equivalent to ASCII `(` / `)` and given the same bracket id, so they mispair with ASCII parentheses.

## Fix
Restrict bracket-equivalence folding to canonical decompositions: when field 5 begins with a `<...>` tag, it is a compatibility decomposition and is not treated as an equivalence for bracket folding. Canonical mappings (bare hex, e.g. U+2329 -> U+3008) still fold, exactly as before. A guard also prevents writing a sentinel -1 into the equivalence table.

## Verification
Reference string [006F,0028,0627,FF08,0644,0645,0029] (`o(ا（لم)`), base LTR:

- before: embedding levels `0 0 1 1 1 1 1`  (the `)` wrongly pairs with `（`)
- after:  embedding levels `0 0 1 1 1 1 0`

The "after" result matches the Servo unicode-bidi reference implementation. Bracket probe: `FRIBIDI_GET_BRACKETS(0xFF08)` changes from 0x0028 to 0xFF08; the canonical mapping U+2329 -> U+3008 is preserved (0x3008 before and after). The full test suite passes, including the BidiCharacterTest and BidiTest Unicode conformance suites.

The bracket table is generated at build time, so there is no checked-in generated artifact to update -- it regenerates from the patched generator.

Thanks to @xyygudu for the report.

---
This contribution was prepared with AI assistance and reviewed by me before submission.